### PR TITLE
IDL: Remove marker type fields from all types

### DIFF
--- a/examples/tutorial/basic-generics/Anchor.toml
+++ b/examples/tutorial/basic-generics/Anchor.toml
@@ -1,0 +1,9 @@
+[provider]
+cluster = "localnet"
+wallet = "~/.config/solana/id.json"
+
+[programs.localnet]
+basic_1 = "Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS"
+
+[scripts]
+test = "yarn run mocha -t 1000000 tests/"

--- a/examples/tutorial/basic-generics/Cargo.toml
+++ b/examples/tutorial/basic-generics/Cargo.toml
@@ -1,0 +1,4 @@
+[workspace]
+members = [
+  "programs/*"
+]

--- a/examples/tutorial/basic-generics/package.json
+++ b/examples/tutorial/basic-generics/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "basic-1",
+  "version": "0.27.0",
+  "license": "(MIT OR Apache-2.0)",
+  "homepage": "https://github.com/coral-xyz/anchor#readme",
+  "bugs": {
+    "url": "https://github.com/coral-xyz/anchor/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/coral-xyz/anchor.git"
+  },
+  "engines": {
+    "node": ">=11"
+  },
+  "scripts": {
+    "test": "anchor test --skip-lint"
+  }
+}

--- a/examples/tutorial/basic-generics/programs/basic-1/Cargo.toml
+++ b/examples/tutorial/basic-generics/programs/basic-1/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "basic-1"
+version = "0.1.0"
+description = "Created with Anchor"
+rust-version = "1.60"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "basic_1"
+
+[features]
+no-entrypoint = []
+cpi = ["no-entrypoint"]
+
+[dependencies]
+anchor-lang = { path = "../../../../../lang" }

--- a/examples/tutorial/basic-generics/programs/basic-1/Xargo.toml
+++ b/examples/tutorial/basic-generics/programs/basic-1/Xargo.toml
@@ -1,0 +1,2 @@
+[target.bpfel-unknown-unknown.dependencies.std]
+features = []

--- a/examples/tutorial/basic-generics/programs/basic-1/src/lib.rs
+++ b/examples/tutorial/basic-generics/programs/basic-1/src/lib.rs
@@ -1,0 +1,48 @@
+use std::marker::PhantomData;
+
+use anchor_lang::prelude::*;
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkg476zPFsLnS");
+
+#[program]
+mod basic_1 {
+    use super::*;
+
+    pub fn initialize(ctx: Context<Initialize>, data: u64) -> Result<()> {
+        let my_account = &mut ctx.accounts.my_account;
+        my_account.data = data;
+        Ok(())
+    }
+
+    pub fn update(ctx: Context<Update>, data: u64) -> Result<()> {
+        let my_account = &mut ctx.accounts.my_account;
+        my_account.data = data;
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct Initialize<'info> {
+    #[account(init, payer = user, space = 8 + 8)]
+    pub my_account: Account<'info, MyAccount<u64, u32>>,
+    #[account(mut)]
+    pub user: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct Update<'info> {
+    #[account(mut)]
+    pub my_account: Account<'info, MyAccount<u64, u32>>,
+}
+
+#[account]
+pub struct MyAccount<T, U>
+where
+    T: AnchorSerialize + AnchorDeserialize,
+    U: AnchorSerialize + AnchorDeserialize,
+{
+    pub data: T,
+    // Irrelevant Phantom data just to show it's stripped.
+    phanthom: PhantomData<U>,
+}

--- a/examples/tutorial/basic-generics/tests/basic-1.js
+++ b/examples/tutorial/basic-generics/tests/basic-1.js
@@ -1,0 +1,67 @@
+const assert = require("assert");
+const anchor = require("@coral-xyz/anchor");
+const { SystemProgram } = anchor.web3;
+
+describe("basic-1", () => {
+  // Use a local provider.
+  const provider = anchor.AnchorProvider.local();
+
+  // Configure the client to use the local cluster.
+  anchor.setProvider(provider);
+
+  it("Creates and initializes an account in a single atomic transaction (simplified)", async () => {
+    // #region code-simplified
+    // The program to execute.
+    const program = anchor.workspace.Basic1;
+
+    // The Account to create.
+    const myAccount = anchor.web3.Keypair.generate();
+
+    // Create the new account and initialize it with the program.
+    // #region code-simplified
+    await program.methods
+      .initialize(new anchor.BN(1234))
+      .accounts({
+        myAccount: myAccount.publicKey,
+        user: provider.wallet.publicKey,
+        systemProgram: SystemProgram.programId,
+      })
+      .signers([myAccount])
+      .rpc();
+    // #endregion code-simplified
+
+    // Fetch the newly created account from the cluster.
+    const account = await program.account.myAccount.fetch(myAccount.publicKey);
+
+    // Check it's state was initialized.
+    assert.ok(account.data.eq(new anchor.BN(1234)));
+
+    // Store the account for the next test.
+    _myAccount = myAccount;
+  });
+
+  it("Updates a previously created account", async () => {
+    const myAccount = _myAccount;
+
+    // #region update-test
+
+    // The program to execute.
+    const program = anchor.workspace.Basic1;
+
+    // Invoke the update rpc.
+    await program.methods
+      .update(new anchor.BN(4321))
+      .accounts({
+        myAccount: myAccount.publicKey,
+      })
+      .rpc();
+
+    // Fetch the newly updated account.
+    const account = await program.account.myAccount.fetch(myAccount.publicKey);
+
+    // Check it's state was mutated.
+    assert.ok(account.data.eq(new anchor.BN(4321)));
+
+    // #endregion update-test
+  });
+});

--- a/lang/syn/src/idl/pda.rs
+++ b/lang/syn/src/idl/pda.rs
@@ -4,7 +4,6 @@ use crate::parser::context::CrateContext;
 use crate::ConstraintSeedsGroup;
 use crate::{AccountsStruct, Field};
 use std::collections::HashMap;
-use std::str::FromStr;
 use syn::{Expr, ExprLit, Lit};
 
 // Parses a seeds constraint, extracting the IdlSeed types.
@@ -144,7 +143,7 @@ impl<'a> PdaParser<'a> {
     }
 
     fn parse_instruction(&self, seed_path: &SeedPath) -> Option<IdlSeed> {
-        let idl_ty = IdlType::from_str(self.ix_args.get(&seed_path.name()).unwrap()).ok()?;
+        let idl_ty = IdlType::from_str(self.ix_args.get(&seed_path.name()).unwrap()).unwrap()?;
         Some(IdlSeed::Arg(IdlSeedArg {
             ty: idl_ty,
             path: seed_path.path(),
@@ -159,7 +158,7 @@ impl<'a> PdaParser<'a> {
             .consts()
             .find(|c| c.ident == seed_path.name())
             .unwrap();
-        let idl_ty = IdlType::from_str(&parser::tts_to_string(&const_item.ty)).ok()?;
+        let idl_ty = IdlType::from_str(&parser::tts_to_string(&const_item.ty)).unwrap()?;
 
         let idl_ty_value = parser::tts_to_string(&const_item.expr);
         let idl_ty_value = str_lit_to_array(&idl_ty, &idl_ty_value);
@@ -180,7 +179,7 @@ impl<'a> PdaParser<'a> {
             .unwrap()
             .1;
 
-        let idl_ty = IdlType::from_str(&parser::tts_to_string(&static_item.ty)).ok()?;
+        let idl_ty = IdlType::from_str(&parser::tts_to_string(&static_item.ty)).unwrap()?;
 
         let idl_ty_value = parser::tts_to_string(&static_item.expr);
         let idl_ty_value = str_lit_to_array(&idl_ty, &idl_ty_value);
@@ -342,7 +341,7 @@ fn parse_field_path(ctx: &CrateContext, strct: &syn::ItemStruct, path: &mut &[St
 
     // The path is empty so this must be a primitive type.
     if path.is_empty() {
-        return next_field_ty_str.parse().unwrap();
+        return IdlType::from_str(&next_field_ty_str).unwrap().unwrap();
     }
 
     // Get the rust representation of hte field's struct.


### PR DESCRIPTION
Rust marker types (`PhantomData` and `PhantomPinned`) are irrelevant for TypeScript and they don't have any impact on the memory layout of the structer. They exist purely for Rust compiler to recognize the ownership of a generic type which is not a direct memeber of the given struct.

Before this change, `PhantomData` fields were included in IDL and then TypeScript programs using them were failing to find the type. This change fixes that just by removing them.