### PR TITLE
PSP: Fix the `yarn test` and `yarn build` commands

### DIFF
--- a/cli/src/psp_template.rs
+++ b/cli/src/psp_template.rs
@@ -579,8 +579,8 @@ pub fn ts_package_json_psp(jest: bool, name: &str) -> String {
     "scripts": {{
         "lint:fix": "prettier */*.js \"*/**/*{{.js,.ts}}\" -w",
         "lint": "prettier */*.js \"*/**/*{{.js,.ts}}\" --check",
-        "test": "light test --testCommand {0} --programName {1} --programAddress {2}",
-        "build": "light build --name {1}"
+        "test": "light test --projectName {0} --programAddress {1}",
+        "build": "light build --name {0}"
     }},
     "dependencies": {{
         "@coral-xyz/anchor": "^{VERSION}",
@@ -601,7 +601,6 @@ pub fn ts_package_json_psp(jest: bool, name: &str) -> String {
 }}
 "#,
             name,
-            name.to_snake_case(),
             default_program_id()
         )
     }


### PR DESCRIPTION
We need the original name without the case conversion.