### PR TITLE
PSP: Append a suffix to the second circom instance name

### DIFF
--- a/cli/src/psp_template.rs
+++ b/cli/src/psp_template.rs
@@ -885,7 +885,7 @@ include "../node_modules/@lightprotocol/zk.js/node_modules/circomlib/circuits/co
 // will create a new instance of the circuit
 #[instance]
 {{
-    fileName: {},
+    fileName: {}_main,
     config(),
     nrAppUtoxs: 1,
     publicInputs: [currentSlot]
@@ -912,7 +912,7 @@ template {}() {{
 // throw error when there is no #[instance]
 // throw error when there is no #[lightTransaction(verifierTwo)]
 "#,
-        name.to_upper_camel_case(),
+        name.to_lower_camel_case(),
         name.to_lower_camel_case()
     )
 }


### PR DESCRIPTION
Before this change, the name of the second circom file was just made by conversion to upper camel case, but that causes conflicts on macOS, where file names are case insensitive.