### PR TITLE
IDL: Use cargo-expand to expand macros in code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2609,6 +2609,7 @@ dependencies = [
  "flate2",
  "heck 0.4.1",
  "light-anchor-client",
+ "light-anchor-expand",
  "light-anchor-lang",
  "light-anchor-syn",
  "pathdiff",
@@ -2647,6 +2648,17 @@ dependencies = [
  "thiserror",
  "tokio",
  "url",
+]
+
+[[package]]
+name = "light-anchor-expand"
+version = "0.28.0"
+dependencies = [
+ "anyhow",
+ "cargo_toml",
+ "chrono",
+ "heck 0.4.1",
+ "serde_json",
 ]
 
 [[package]]
@@ -2694,6 +2706,7 @@ dependencies = [
  "cargo",
  "cargo_metadata",
  "heck 0.3.3",
+ "light-anchor-expand",
  "proc-macro2 1.0.60",
  "quote 1.0.28",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "lang",
     "lang/attribute/*",
     "lang/derive/*",
+    "lang/expand",
     "lang/syn",
     "spl",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -18,6 +18,7 @@ default = []
 
 [dependencies]
 anchor-client = { path = "../client", version = "0.28.0", package = "light-anchor-client" }
+anchor-expand = { path = "../lang/expand", version = "0.28.0", package = "light-anchor-expand" }
 anchor-lang = { path = "../lang", version = "0.28.0", package = "light-anchor-lang" }
 anchor-syn = { path = "../lang/syn", features = ["event-cpi", "idl", "init-if-needed"], version = "0.28.0", package = "light-anchor-syn" }
 anyhow = "1.0.32"

--- a/lang/expand/Cargo.toml
+++ b/lang/expand/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "light-anchor-expand"
+version = "0.28.0"
+authors = ["Anchor Maintainers <accounts@200ms.io>"]
+repository = "https://github.com/coral-xyz/anchor"
+license = "Apache-2.0"
+description = "Utility library for calling cargo-expand"
+rust-version = "1.60"
+edition = "2021"
+
+[dependencies]
+anyhow = "1"
+cargo_toml = "0.13.0"
+chrono = "0.4.19"
+heck = "0.4.0"
+serde_json = "1"

--- a/lang/expand/src/lib.rs
+++ b/lang/expand/src/lib.rs
@@ -1,0 +1,56 @@
+use std::{ffi::OsString, fs, path::PathBuf, process::Stdio};
+
+use anyhow::Result;
+
+pub fn expand_program(
+    root: PathBuf,
+    package_name: &str,
+    version: &str,
+    expansions_path: Option<PathBuf>,
+    cargo_args: &[String],
+) -> Result<Vec<u8>> {
+    let target_dir_arg = match expansions_path {
+        Some(ref expansions_path) => {
+            let mut target_dir_arg = OsString::from("--target-dir=");
+            target_dir_arg.push(expansions_path.join("expand-target"));
+            Some(target_dir_arg)
+        }
+        None => None,
+    };
+
+    let mut cmd = std::process::Command::new("cargo");
+    let cmd = cmd.arg("expand");
+    if let Some(target_dir_arg) = target_dir_arg {
+        cmd.arg(target_dir_arg);
+    }
+    let exit = cmd
+        .current_dir(root)
+        .arg(&format!("--package={package_name}"))
+        .args(cargo_args)
+        .stderr(Stdio::inherit())
+        .output()
+        .map_err(|e| anyhow::format_err!("{}", e.to_string()))?;
+    if !exit.status.success() {
+        eprintln!("'cargo expand' failed. Perhaps you have not installed 'cargo-expand'? https://github.com/dtolnay/cargo-expand#installation");
+        std::process::exit(exit.status.code().unwrap_or(1));
+    }
+
+    if let Some(ref expansions_path) = expansions_path {
+        let program_expansions_path = expansions_path.join(package_name);
+        fs::create_dir_all(&program_expansions_path)?;
+
+        // let version = cargo.version();
+        let time = chrono::Utc::now().to_string().replace(' ', "_");
+        let file_path = program_expansions_path.join(format!("{package_name}-{version}-{time}.rs"));
+        fs::write(&file_path, &exit.stdout)
+            .map_err(|e| anyhow::format_err!("{}", e.to_string()))?;
+
+        println!(
+            "Expanded {} into file {}\n",
+            package_name,
+            file_path.to_string_lossy()
+        );
+    }
+
+    Ok(exit.stdout)
+}

--- a/lang/syn/Cargo.toml
+++ b/lang/syn/Cargo.toml
@@ -19,6 +19,7 @@ seeds = []
 event-cpi = []
 
 [dependencies]
+anchor-expand = { path = "../expand", package = "light-anchor-expand" }
 anyhow = "1"
 bs58 = "0.5"
 heck = "0.3"


### PR DESCRIPTION
cargo-expand is already used for the `anchor expand` subcommand. In contrast to using `cargo +nightly rustc --profile=check -- -Zunpretty=expanded`, it works without problems in all of our Anchor programs.

The code for using cargo-expand used to be a part of anchor-cli crate, but since we had to use it in anchor-syn, this change moves it to a separate crate.