### PR TITLE
IDL: Disable rustfmt when expanding the code to parse IDL from

### DIFF
--- a/lang/syn/src/parser/context.rs
+++ b/lang/syn/src/parser/context.rs
@@ -120,7 +120,8 @@ impl ParsedModule {
     ) -> Result<BTreeMap<String, ParsedModule>, anyhow::Error> {
         let mut modules = BTreeMap::new();
 
-        let mut args = Vec::with_capacity(2);
+        let mut args = Vec::with_capacity(3);
+        args.push("--ugly".to_owned());
         if let Some(features) = features {
             args.push("--features".to_owned());
             args.push(features.join(","));


### PR DESCRIPTION
Apparently, the newest rustfmt doesn't like the account constraint syntax in Anchor.

This code:

```rust
\#[account(constraint = foo == bar @ ErrorCode::Baz)]
```

After rustfmt, becomes:

```rust
\#[account(constraint = foo = = bar @ ErrorCode::Baz)]
```

So it splits `==` to `= =`. syn is able to parse the former, but not the latter.

This looks like a bug in rustfmt, but for now, let's disable it as a workaround.